### PR TITLE
chore: fix root lint config

### DIFF
--- a/docs/dev-workflow/qa/2026-04-24-lint-config.md
+++ b/docs/dev-workflow/qa/2026-04-24-lint-config.md
@@ -1,0 +1,34 @@
+---
+task_slug: lint-config
+branch: chore/lint-config
+base_commit: ee60b474c4ef9ba792f4c1a9d1efbe8372b54284
+stage: qa
+---
+
+# QA Report
+
+## Verification Matrix
+
+- unit: run
+- integration: not applicable
+- build/lint/type: run
+- curl/api: not applicable
+- playwright: not applicable
+- manual: not applicable
+
+## Evidence
+
+- commands:
+  - `bun run lint`
+  - `bun run build`
+  - `bun run test:unit`
+- outputs:
+  - `bun run lint`: passed.
+  - `bun run build`: failed with existing `lambda/app.ts` type errors at lines
+    123, 124, 180, and 199.
+  - `bun run test:unit`: passed 3 test suites, 14 tests.
+- residual risks:
+  - Build remains blocked by pre-existing `lambda/app.ts` type errors outside
+    this lint configuration chore.
+  - Frontend and data-handler linting remain delegated to their own project
+    configs and are not verified by the root lint command.

--- a/docs/dev-workflow/specs/2026-04-24-lint-config.md
+++ b/docs/dev-workflow/specs/2026-04-24-lint-config.md
@@ -1,0 +1,67 @@
+---
+task_slug: lint-config
+branch: chore/lint-config
+base_commit: ee60b474c4ef9ba792f4c1a9d1efbe8372b54284
+source_artifact_type: plain feature brief
+source_artifact_snapshot: "Another developer noted that the linting configuration in this repo needs work."
+stage: spec
+---
+
+# Lint Config Spec
+
+## Scope
+
+Fix the root lint configuration so `bun run lint` runs against the intended
+root TypeScript project and does not parse nested independent projects against
+the root `tsconfig.json`.
+
+## Current Evidence
+
+Baseline `bun run lint` fails with 96 parsing errors. The failures are for
+`frontend-react/**` and `data-handler-ts/**` files being parsed with
+`parserOptions.project: ./tsconfig.json`, even though those files are excluded
+from the root TypeScript project.
+
+Baseline `bun run build` also fails in `lambda/app.ts`. That is an existing
+type-check issue and is out of scope for this lint configuration chore.
+
+## Non-Goals
+
+- Do not change API route behavior.
+- Do not change auth, tenant boundaries, permissions, device commands, or event
+  handlers.
+- Do not change DynamoDB schemas, repositories, or queries.
+- Do not change CDK resources or deployment configuration.
+- Do not lint or refactor `frontend-react/` or `data-handler-ts/` from the root
+  command.
+- Do not update package dependencies or the lockfile.
+
+## Acceptance Criteria
+
+- `bun run lint` no longer reports parser errors for `frontend-react/**` or
+  `data-handler-ts/**`.
+- Root lint still covers root TypeScript sources included by the root
+  `tsconfig.json`.
+- Generated JavaScript/declaration artifacts remain ignored by root lint.
+- No application TypeScript source behavior changes are required.
+
+## Adversarial Review
+
+- API contract drift: none expected because only lint configuration should
+  change.
+- Auth / tenant boundaries: none expected; no auth code changes.
+- Device / event side effects: none expected; no event handler or IoT command
+  changes.
+- DynamoDB schema / query impact: none expected; no data layer changes.
+- CDK / deploy blast radius: none expected; lint-only local tooling change.
+- Rollback path: revert the lint config commit.
+- Failure modes: overly broad ignores could hide root code; overly broad lint
+  targets could reintroduce nested-project parser errors.
+- Testability: verify with `bun run lint`; run `bun run build` and report
+  existing baseline type failures separately.
+
+## Test Plan
+
+- Run `bun run lint`.
+- Run `bun run build` for type-check evidence; record any pre-existing failures
+  that remain outside this chore.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,85 @@
+import js from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
+
+const rootTypeScriptFiles = [
+  '*.{ts,tsx}',
+  '{bin,deployment,lambda,lib,scripts,shared,test}/**/*.{ts,tsx}',
+];
+
+export default [
+  {
+    ignores: [
+      '**/*.js',
+      '**/*.d.ts',
+      'node_modules/**',
+      'cdk.out/**',
+      'dist/**',
+      'build/**',
+      'coverage/**',
+      'frontend-react/**',
+      'data-handler-ts/**',
+    ],
+  },
+  {
+    files: rootTypeScriptFiles,
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
+        Request: 'readonly',
+        Response: 'readonly',
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        jest: 'readonly',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-var-requires': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+
+      // TypeScript handles identifier resolution for TS files.
+      'no-undef': 'off',
+      'no-unused-vars': 'off',
+      'no-redeclare': 'off',
+      'no-console': 'off',
+      'no-debugger': 'error',
+      'no-alert': 'error',
+      'no-var': 'error',
+      'prefer-const': 'error',
+      'no-unused-expressions': 'error',
+      'no-unreachable': 'error',
+      'no-constant-condition': 'error',
+      'no-empty': 'error',
+      'no-extra-semi': 'error',
+      'no-irregular-whitespace': 'error',
+      'no-trailing-spaces': 'off',
+      'no-unused-labels': 'error',
+      semi: 'off',
+      quotes: 'off',
+      indent: 'off',
+      'eol-last': 'off',
+    },
+  },
+];


### PR DESCRIPTION
- spec: docs/dev-workflow/specs/2026-04-24-lint-config.md
- current stage: QA complete
- local status: lint passes; unit test target passes; build still blocked by pre-existing lambda/app.ts type errors
- ci status: pending/not inspected
- residual risks: frontend-react and data-handler-ts remain linted by their own project configs, not by root lint