### PR TITLE
[codex] Adjust frontend degraded thresholds

### DIFF
--- a/frontend-react/src/pages/Dashboard.tsx
+++ b/frontend-react/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { deviceAPI } from '../services/api';
 import { Device } from '../types';
+import { DeviceStatus, getDeviceStatus, hoursSince } from '../utils/deviceStatus.ts';
 import {
   FiActivity,
   FiAlertCircle,
@@ -18,29 +19,6 @@ const getLinkTypeName = (linkType?: number): string => {
   if (linkType === 1) return 'BLE';
   if (linkType === 4) return 'LoRA';
   return 'Unknown';
-};
-
-const hoursSince = (dateString?: string): number | null => {
-  if (!dateString) return null;
-  try {
-    const date = new Date(dateString);
-    const now = new Date();
-    return (now.getTime() - date.getTime()) / (1000 * 60 * 60);
-  } catch (e) {
-    return null;
-  }
-};
-
-type DeviceStatus = 'online' | 'degraded' | 'offline' | 'no_data';
-
-const getDeviceStatus = (device: Device): DeviceStatus => {
-  const ageHours = hoursSince(device.updated_at);
-
-  if (ageHours === null) return 'no_data';
-  if (ageHours > 24) return 'offline';
-  if (ageHours > 4) return 'degraded';
-  if (device.last_rx_rssi !== undefined && device.last_rx_rssi <= -85) return 'degraded';
-  return 'online';
 };
 
 const statusLabel: Record<DeviceStatus, string> = {

--- a/frontend-react/src/pages/DeviceDetail.tsx
+++ b/frontend-react/src/pages/DeviceDetail.tsx
@@ -17,8 +17,7 @@ import {
 import DeviceEvents from '../components/DeviceEvents.tsx';
 import ScheduleEvent from '../components/ScheduleEvent.tsx';
 import DeviceTypeDisplay from '../components/ui/DeviceTypeDisplay.tsx';
-
-type DeviceStatus = 'online' | 'degraded' | 'offline' | 'no_data';
+import { DeviceStatus, getDeviceStatus, hoursSince } from '../utils/deviceStatus.ts';
 
 const getLinkTypeName = (linkType?: number): string => {
   if (linkType === 1) return 'BLE';
@@ -35,17 +34,6 @@ const formatDate = (dateString?: string): string => {
   }
 };
 
-const hoursSince = (dateString?: string): number | null => {
-  if (!dateString) return null;
-  try {
-    const date = new Date(dateString);
-    const now = new Date();
-    return (now.getTime() - date.getTime()) / (1000 * 60 * 60);
-  } catch (e) {
-    return null;
-  }
-};
-
 const formatTimeAgo = (dateString?: string): string => {
   if (!dateString) return 'No check-ins';
   const ageHours = hoursSince(dateString);
@@ -53,15 +41,6 @@ const formatTimeAgo = (dateString?: string): string => {
   if (ageHours < 1) return `${Math.max(1, Math.round(ageHours * 60))}m ago`;
   if (ageHours < 24) return `${Math.round(ageHours)}h ago`;
   return `${Math.round(ageHours / 24)}d ago`;
-};
-
-const getDeviceStatus = (device: Device): DeviceStatus => {
-  const ageHours = hoursSince(device.updated_at);
-  if (ageHours === null) return 'no_data';
-  if (ageHours > 24) return 'offline';
-  if (ageHours > 4) return 'degraded';
-  if (device.last_rx_rssi !== undefined && device.last_rx_rssi <= -85) return 'degraded';
-  return 'online';
 };
 
 const statusLabel: Record<DeviceStatus, string> = {

--- a/frontend-react/src/pages/Devices.tsx
+++ b/frontend-react/src/pages/Devices.tsx
@@ -13,28 +13,7 @@ import { Device } from '../types/index.ts';
 import { DataTable, deviceColumns } from '../components/data/index.ts';
 import { Button } from '../components/ui/Button.tsx';
 import { getDeviceTypeDescription } from '../utils/deviceTypes.ts';
-
-type DeviceStatus = 'online' | 'degraded' | 'offline' | 'no_data';
-
-const hoursSince = (dateString?: string): number | null => {
-  if (!dateString) return null;
-  try {
-    const date = new Date(dateString);
-    const now = new Date();
-    return (now.getTime() - date.getTime()) / (1000 * 60 * 60);
-  } catch (e) {
-    return null;
-  }
-};
-
-const getDeviceStatus = (device: Device): DeviceStatus => {
-  const ageHours = hoursSince(device.updated_at);
-  if (ageHours === null) return 'no_data';
-  if (ageHours > 24) return 'offline';
-  if (ageHours > 4) return 'degraded';
-  if (device.last_rx_rssi !== undefined && device.last_rx_rssi <= -85) return 'degraded';
-  return 'online';
-};
+import { DeviceStatus, getDeviceStatus, hoursSince } from '../utils/deviceStatus.ts';
 
 const statusPriority: Record<DeviceStatus, number> = {
   offline: 0,

--- a/frontend-react/src/utils/deviceStatus.test.ts
+++ b/frontend-react/src/utils/deviceStatus.test.ts
@@ -1,0 +1,30 @@
+import { Device } from '../types/index.ts';
+import { getDeviceStatus } from './deviceStatus.ts';
+
+const baseDevice = (overrides: Partial<Device> = {}): Device => ({
+  cta_version: '1',
+  firmware_date: '2024-01-01',
+  model_number: 'model',
+  device_id: 'device-1',
+  device_type: 'type',
+  capability_bitmap: '0',
+  device_revision: '1',
+  firmware_version: '1',
+  serial_number: 'serial',
+  vendor_id: 'vendor',
+  ...overrides,
+});
+
+const hoursAgo = (hours: number): string => new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+describe('getDeviceStatus', () => {
+  it('marks devices degraded after 6 hours without updates', () => {
+    expect(getDeviceStatus(baseDevice({ updated_at: hoursAgo(5.9) }))).toBe('online');
+    expect(getDeviceStatus(baseDevice({ updated_at: hoursAgo(6.1) }))).toBe('degraded');
+  });
+
+  it('marks devices degraded when RSSI is -100 dBm or weaker', () => {
+    expect(getDeviceStatus(baseDevice({ updated_at: hoursAgo(1), last_rx_rssi: -99 }))).toBe('online');
+    expect(getDeviceStatus(baseDevice({ updated_at: hoursAgo(1), last_rx_rssi: -100 }))).toBe('degraded');
+  });
+});

--- a/frontend-react/src/utils/deviceStatus.ts
+++ b/frontend-react/src/utils/deviceStatus.ts
@@ -1,0 +1,24 @@
+import { Device } from '../types/index.ts';
+
+export type DeviceStatus = 'online' | 'degraded' | 'offline' | 'no_data';
+
+export const hoursSince = (dateString?: string): number | null => {
+  if (!dateString) return null;
+  try {
+    const date = new Date(dateString);
+    const now = new Date();
+    return (now.getTime() - date.getTime()) / (1000 * 60 * 60);
+  } catch (e) {
+    return null;
+  }
+};
+
+export const getDeviceStatus = (device: Device): DeviceStatus => {
+  const ageHours = hoursSince(device.updated_at);
+
+  if (ageHours === null) return 'no_data';
+  if (ageHours > 24) return 'offline';
+  if (ageHours > 6) return 'degraded';
+  if (device.last_rx_rssi !== undefined && device.last_rx_rssi <= -100) return 'degraded';
+  return 'online';
+};


### PR DESCRIPTION
## Summary

- Change frontend degraded status thresholds to more than 6 hours stale or RSSI at/below -100 dBm.
- Move duplicated device status logic into a shared frontend utility.
- Add regression tests for the stale and RSSI degraded boundaries.

## Impact

Dashboard, device list, and device detail views now use the same status calculation. Devices between 4 and 6 hours stale, or with RSSI between -99 and -85 dBm, no longer show as degraded.

## Validation

- `CI=true bun run test -- --watchAll=false src/utils/deviceStatus.test.ts`
- `bun run lint:check`
- `bun run build`