### PR TITLE
docs: fix auth and event OpenAPI schemas

### DIFF
--- a/docs/guides/cta-2045-events.md
+++ b/docs/guides/cta-2045-events.md
@@ -31,7 +31,6 @@ Send:
     - `255` (0xFF): special (only allowed with `value=0` in SetAdvancedLoadUp; also used by GetAdvancedLoadUp to indicate inactive)
     - `4..254`: reserved (do not use; rejected by API)
   - `suggested_load_up_efficiency`: UInt8 (0-255, set `0` if unused)
-  - `event_id`: UUID (CTA Event ID sent to the device; GridCube encodes the first 4 bytes)
   - `start_randomization`: minutes (UInt8)
   - `end_randomization`: minutes (UInt8)
 
@@ -39,7 +38,6 @@ Send:
 
 ```json
 {
-  "event_id": "8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
   "event_type": "ADVANCED_LOAD_UP",
   "event_data": {
     "device_id": "000012",
@@ -48,7 +46,6 @@ Send:
     "value": 3,
     "units": 3,
     "suggested_load_up_efficiency": 0,
-    "event_id": "8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
     "start_randomization": 0,
     "end_randomization": 0
   }
@@ -59,7 +56,6 @@ Send:
 
 ```json
 {
-  "event_id": "9d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
   "event_type": "ADVANCED_LOAD_UP",
   "event_data": {
     "device_id": "000012",
@@ -68,7 +64,6 @@ Send:
     "value": 0,
     "units": 255,
     "suggested_load_up_efficiency": 0,
-    "event_id": "9d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
     "start_randomization": 0,
     "end_randomization": 0
   }
@@ -80,4 +75,5 @@ Send:
 - `LOAD_UP.duration` is seconds, but `ADVANCED_LOAD_UP.duration` is minutes.
 - Advanced Load Up requires `units` to be one of `0,1,2,3,255`; `4..254` are reserved.
 - When `value=0`, `units` must be `255 (0xFF)`.
-- The API request has a top-level `event_id`, but Advanced Load Up also has `event_data.event_id` for the CTA Event ID.
+- Do not send `event_id` or `event_sent` in API requests. The API returns the canonical event ID and delivery status in responses.
+- For Advanced Load Up, the CTA Event ID sent to the device is server-owned and returned in response `event_data.event_id` when available.

--- a/docs/security/gridcube-security-whitepaper.md
+++ b/docs/security/gridcube-security-whitepaper.md
@@ -235,7 +235,6 @@ const deviceIdSchema = z.union([
 
 const eventRequestSchema = z.discriminatedUnion("event_type", [
     z.object({
-        event_id: z.string(),
         event_type: z.literal(EventType.LOAD_UP),
         event_data: loadUpSchema,
     }),

--- a/docs/security/security-practices.md
+++ b/docs/security/security-practices.md
@@ -166,7 +166,6 @@ const deviceSchema = z.object({
 // From lambda/events/eventsSchema.ts
 const eventRequestSchema = z.discriminatedUnion("event_type", [
     z.object({
-        event_id: z.string(),
         event_type: z.literal(EventType.LOAD_UP),
         event_data: loadUpSchema,
     }),
@@ -298,7 +297,6 @@ const deviceIdSchema = z.union([
 // Event data validation with discriminated unions
 const eventRequestSchema = z.discriminatedUnion("event_type", [
     z.object({
-        event_id: z.string(),
         event_type: z.literal(EventType.LOAD_UP),
         event_data: loadUpSchema,
     }),

--- a/lambda/app.ts
+++ b/lambda/app.ts
@@ -9,20 +9,432 @@ import authRoutes from './utils/authRoutes'
 import { auth } from './utils/auth'
 
 type OpenApiContent = {
+  example?: unknown
   examples?: Record<string, unknown>
+  schema?: Record<string, unknown>
 }
 
-type OpenApiSpec = Record<string, unknown> & {
-  paths?: Record<
+type OpenApiOperation = {
+  description?: string
+  requestBody?: {
+    required?: boolean
+    content?: Record<string, OpenApiContent>
+  }
+  responses?: Record<string, { content?: Record<string, OpenApiContent>; description?: string }>
+  security?: Record<string, unknown>[]
+}
+
+type OpenApiSpec = Record<string, any> & {
+  components?: Record<string, any>
+  paths?: Record<string, { post?: OpenApiOperation }>
+}
+
+const eventRequestSchemaTitles = [
+  'LoadUpEventRequest',
+  'GridEmergencyEventRequest',
+  'CriticalPeakEventRequest',
+  'StartShedEventRequest',
+  'EndShedEventRequest',
+  'InfoRequestEventRequest',
+  'AdvancedLoadUpEventRequest',
+  'CustomerOverrideEventRequest',
+  'SetUtcTimeEventRequest',
+  'GetUtcTimeEventRequest',
+  'SetBitmapEventRequest',
+  'RequestConnectionInfoEventRequest',
+  'StartDataPublishEventRequest',
+]
+
+const eventDataSchemaTitles = [
+  'LoadUpEventData',
+  'GridEmergencyEventData',
+  'CriticalPeakEventData',
+  'StartShedEventData',
+  'EndShedEventData',
+  'InfoRequestEventData',
+  'AdvancedLoadUpEventData',
+  'CustomerOverrideEventData',
+  'SetUtcTimeEventData',
+  'GetUtcTimeEventData',
+  'SetBitmapEventData',
+  'RequestConnectionInfoEventData',
+  'StartDataPublishEventData',
+]
+
+const deviceIdOpenApiSchema = {
+  anyOf: [
+    { type: 'string', format: 'uuid' },
+    { type: 'string', pattern: '^\\d{6}$' },
+    {
+      type: 'array',
+      items: {
+        anyOf: [
+          { type: 'string', format: 'uuid' },
+          { type: 'string', pattern: '^\\d{6}$' },
+        ],
+      },
+    },
+  ],
+}
+
+function eventDataSchema(properties: Record<string, unknown>, required: string[] = ['device_id']) {
+  return {
+    type: 'object',
+    properties: {
+      device_id: deviceIdOpenApiSchema,
+      ...properties,
+    },
+    required,
+  }
+}
+
+function makeEventRequestOpenApiSchema() {
+  const variants = [
+    {
+      type: 'LOAD_UP',
+      data: eventDataSchema(
+        {
+          start_time: { type: 'string', format: 'date-time' },
+          duration: { type: 'number' },
+        },
+        ['device_id', 'start_time'],
+      ),
+    },
+    {
+      type: 'GRID_EMERGENCY',
+      data: eventDataSchema({ start_time: { type: 'string', format: 'date-time' } }, ['device_id', 'start_time']),
+    },
+    {
+      type: 'CRITICAL_PEAK',
+      data: eventDataSchema({ start_time: { type: 'string', format: 'date-time' } }, ['device_id', 'start_time']),
+    },
+    {
+      type: 'START_SHED',
+      data: eventDataSchema(
+        {
+          start_time: { type: 'string', format: 'date-time' },
+          duration: { type: 'number' },
+        },
+        ['device_id', 'start_time'],
+      ),
+    },
+    {
+      type: 'END_SHED',
+      data: eventDataSchema({ start_time: { type: 'string', format: 'date-time' } }),
+    },
+    {
+      type: 'INFO_REQUEST',
+      data: eventDataSchema({ timestamp: { type: 'string', format: 'date-time' } }),
+    },
+    {
+      type: 'ADVANCED_LOAD_UP',
+      data: eventDataSchema(
+        {
+          start_time: { type: 'string', format: 'date-time' },
+          duration: { type: 'integer', minimum: 0, maximum: 65535 },
+          value: { type: 'integer', minimum: 0, maximum: 65535 },
+          units: { type: 'integer', minimum: 0, maximum: 255 },
+          suggested_load_up_efficiency: { type: 'integer', minimum: 0, maximum: 255 },
+          start_randomization: { type: 'integer', minimum: 0, maximum: 255 },
+          end_randomization: { type: 'integer', minimum: 0, maximum: 255 },
+        },
+        [
+          'device_id',
+          'start_time',
+          'duration',
+          'value',
+          'units',
+          'suggested_load_up_efficiency',
+          'start_randomization',
+          'end_randomization',
+        ],
+      ),
+    },
+    {
+      type: 'CUSTOMER_OVERRIDE',
+      data: eventDataSchema({ override: { type: 'boolean' } }, ['device_id', 'override']),
+    },
+    {
+      type: 'SET_UTC_TIME',
+      data: eventDataSchema(
+        {
+          utc_seconds: { type: 'number' },
+          utc_offset: { type: 'number' },
+          dst_offset: { type: 'number' },
+        },
+        ['device_id', 'utc_seconds', 'utc_offset', 'dst_offset'],
+      ),
+    },
+    { type: 'GET_UTC_TIME', data: eventDataSchema({}) },
+    {
+      type: 'SET_BITMAP',
+      data: eventDataSchema(
+        {
+          bit_number: { type: 'number', minimum: 0, maximum: 255 },
+          set_value: { type: 'boolean' },
+        },
+        ['device_id', 'bit_number', 'set_value'],
+      ),
+    },
+    { type: 'REQUEST_CONNECTION_INFO', data: eventDataSchema({}) },
+    {
+      type: 'START_DATA_PUBLISH',
+      data: eventDataSchema({ interval_minutes: { type: 'number', minimum: 1, maximum: 65535 } }, [
+        'device_id',
+        'interval_minutes',
+      ]),
+    },
+  ]
+
+  return {
+    oneOf: variants.map((variant, index) => ({
+      title: eventRequestSchemaTitles[index],
+      type: 'object',
+      properties: {
+        event_type: { type: 'string', const: variant.type },
+        event_data: variant.data,
+      },
+      required: ['event_type', 'event_data'],
+    })),
+    discriminator: { propertyName: 'event_type' },
+  }
+}
+
+function ensureOpenApiComponents(spec: OpenApiSpec) {
+  spec.components = spec.components || {}
+  spec.components.schemas = spec.components.schemas || {}
+  spec.components.securitySchemes = spec.components.securitySchemes || {}
+
+  spec.components.securitySchemes.bearerAuth = {
+    type: 'http',
+    scheme: 'bearer',
+    bearerFormat: 'JWT',
+    description: 'Send the login or refresh token as `Authorization: Bearer <token>` on protected endpoints.',
+  }
+
+  spec.components.schemas.Error = {
+    type: 'object',
+    properties: {
+      message: { type: 'string', example: 'Unauthorized - Invalid token' },
+      error: { type: 'string', example: 'Token expired' },
+    },
+  }
+}
+
+function annotateEventSchemas(spec: OpenApiSpec) {
+  const postEvents = spec.paths?.['/events']?.post
+  const appJson = postEvents?.requestBody?.content?.['application/json']
+  const eventRequestSchema = appJson?.schema as Record<string, any> | undefined
+
+  if (appJson && (!eventRequestSchema || Object.keys(eventRequestSchema).length === 0)) {
+    appJson.schema = makeEventRequestOpenApiSchema()
+  }
+
+  if (Array.isArray(eventRequestSchema?.oneOf)) {
+    eventRequestSchema.discriminator = { propertyName: 'event_type' }
+    eventRequestSchema.oneOf.forEach((variant: Record<string, unknown>, index: number) => {
+      variant.title = eventRequestSchemaTitles[index]
+    })
+  }
+
+  const responseSchema = postEvents?.responses?.['200']?.content?.['application/json']?.schema as Record<string, any> | undefined
+  const eventSchema = responseSchema?.properties?.successful_events?.items
+  const eventId = eventSchema?.properties?.event_id
+  if (eventId) {
+    eventId.readOnly = true
+    eventId.description = 'Canonical server-generated event identifier. Returned by the API; do not send in event requests.'
+  }
+
+  const eventData = eventSchema?.properties?.event_data
+  if (eventData?.anyOf && !eventData.oneOf) {
+    eventData.oneOf = eventData.anyOf
+    delete eventData.anyOf
+  }
+
+  if (Array.isArray(eventData?.oneOf)) {
+    eventData.oneOf.forEach((variant: Record<string, any>, index: number) => {
+      variant.title = eventDataSchemaTitles[index]
+
+      const eventSent = variant.properties?.event_sent
+      if (eventSent) {
+        eventSent.readOnly = true
+        eventSent.description = 'Server-owned delivery status. Returned by the API; do not send in event requests.'
+      }
+
+      const ctaEventId = variant.properties?.event_id
+      if (ctaEventId) {
+        ctaEventId.readOnly = true
+        ctaEventId.description = 'Server-owned CTA-2045 Event ID sent to the device. Returned by the API; do not send in event requests.'
+      }
+    })
+  }
+}
+
+function addAuthExamples(spec: OpenApiSpec) {
+  const authDocs: Record<
     string,
     {
-      post?: {
-        requestBody?: {
-          content?: Record<string, OpenApiContent>
-        }
+      requestSchema: Record<string, unknown>
+      requestExample: Record<string, unknown>
+      successStatus: '200' | '201'
+      successExample: Record<string, unknown>
+      errorStatus: '400' | '401'
+      errorExample: Record<string, unknown>
+      description: string
+    }
+  > = {
+    '/public/auth/register': {
+      requestSchema: {
+        type: 'object',
+        required: ['email', 'password', 'name'],
+        properties: {
+          email: { type: 'string', format: 'email' },
+          password: { type: 'string', minLength: 8 },
+          name: { type: 'string' },
+        },
+      },
+      requestExample: { email: 'newuser@example.com', password: 'SecurePass123!', name: 'Jane Doe' },
+      successStatus: '201',
+      successExample: {
+        message: 'User registration successful. Please check your email for confirmation code.',
+        userId: '12345678-1234-1234-1234-123456789012',
+      },
+      errorStatus: '400',
+      errorExample: { message: 'Registration failed', error: 'User already exists' },
+      description: 'Requires `Content-Type: application/json`. No Authorization header is required.',
+    },
+    '/public/auth/confirm-registration': {
+      requestSchema: {
+        type: 'object',
+        required: ['email', 'confirmationCode'],
+        properties: {
+          email: { type: 'string', format: 'email' },
+          confirmationCode: { type: 'string' },
+        },
+      },
+      requestExample: { email: 'newuser@example.com', confirmationCode: '123456' },
+      successStatus: '200',
+      successExample: { message: 'Email confirmed successfully. You can now log in.' },
+      errorStatus: '400',
+      errorExample: { message: 'Confirmation failed', error: 'Invalid verification code provided' },
+      description: 'Requires `Content-Type: application/json`. No Authorization header is required.',
+    },
+    '/public/auth/login': {
+      requestSchema: {
+        type: 'object',
+        required: ['email', 'password'],
+        properties: {
+          email: { type: 'string', format: 'email' },
+          password: { type: 'string' },
+        },
+      },
+      requestExample: { email: 'user@example.com', password: 'SecurePass123!' },
+      successStatus: '200',
+      successExample: {
+        message: 'Login successful',
+        token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example',
+        refreshToken: 'eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.example',
+        expiresIn: 3600,
+      },
+      errorStatus: '401',
+      errorExample: { message: 'Login failed', error: 'Incorrect username or password.' },
+      description:
+        'Requires `Content-Type: application/json`. Use the returned `token` as `Authorization: Bearer <token>` on protected endpoints.',
+    },
+    '/public/auth/forgot-password': {
+      requestSchema: {
+        type: 'object',
+        required: ['email'],
+        properties: { email: { type: 'string', format: 'email' } },
+      },
+      requestExample: { email: 'user@example.com' },
+      successStatus: '200',
+      successExample: { message: 'Password reset code sent to your email' },
+      errorStatus: '400',
+      errorExample: { message: 'Password reset request failed', error: 'User not found' },
+      description: 'Requires `Content-Type: application/json`. No Authorization header is required.',
+    },
+    '/public/auth/reset-password': {
+      requestSchema: {
+        type: 'object',
+        required: ['email', 'confirmationCode', 'newPassword'],
+        properties: {
+          email: { type: 'string', format: 'email' },
+          confirmationCode: { type: 'string' },
+          newPassword: { type: 'string', minLength: 8 },
+        },
+      },
+      requestExample: { email: 'user@example.com', confirmationCode: '123456', newPassword: 'NewSecurePass123!' },
+      successStatus: '200',
+      successExample: { message: 'Password reset successful. You can now log in with your new password.' },
+      errorStatus: '400',
+      errorExample: { message: 'Password reset failed', error: 'Invalid verification code provided' },
+      description: 'Requires `Content-Type: application/json`. No Authorization header is required.',
+    },
+    '/public/auth/refresh-token': {
+      requestSchema: {
+        type: 'object',
+        required: ['refreshToken'],
+        properties: { refreshToken: { type: 'string', description: 'Refresh token returned by login.' } },
+      },
+      requestExample: { refreshToken: 'eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.example' },
+      successStatus: '200',
+      successExample: {
+        message: 'Token refresh successful',
+        token: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.example',
+        refreshToken: 'eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiUlNBLU9BRVAifQ.example',
+        expiresIn: 3600,
+      },
+      errorStatus: '401',
+      errorExample: { message: 'Token refresh failed', error: 'Refresh Token has expired' },
+      description:
+        'Requires `Content-Type: application/json`. Send the refresh token in the JSON body; no Authorization header is required.',
+    },
+  }
+
+  for (const [path, docs] of Object.entries(authDocs)) {
+    const operation = spec.paths?.[path]?.post
+    if (!operation) {
+      continue
+    }
+
+    operation.security = []
+    operation.description = `${operation.description || ''}\n\n${docs.description}`.trim()
+    operation.requestBody = {
+      required: true,
+      content: {
+        'application/json': {
+          schema: docs.requestSchema,
+          examples: {
+            validRequest: {
+              summary: 'Valid request',
+              value: docs.requestExample,
+            },
+          },
+        },
+      },
+    }
+
+    const successJson = operation.responses?.[docs.successStatus]?.content?.['application/json']
+    if (successJson) {
+      successJson.examples = {
+        success: {
+          summary: 'Successful response',
+          value: docs.successExample,
+        },
       }
     }
-  >
+
+    const errorJson = operation.responses?.[docs.errorStatus]?.content?.['application/json']
+    if (errorJson) {
+      errorJson.examples = {
+        commonError: {
+          summary: 'Common error response',
+          value: docs.errorExample,
+        },
+      }
+    }
+  }
 }
 
 // Main Hono app factory.
@@ -148,6 +560,10 @@ For technical support or questions about this API, please contact our developmen
       // Inject copy/paste examples for CTA-2045 Advanced Load Up.
       // Some requestBody fields are generated by zValidator docs and would otherwise drop describeRoute examples.
       try {
+        ensureOpenApiComponents(spec)
+        annotateEventSchemas(spec)
+        addAuthExamples(spec)
+
         const postEvents = spec?.paths?.['/events']?.post
         const appJson = postEvents?.requestBody?.content?.['application/json']
         if (appJson && typeof appJson === 'object') {
@@ -156,7 +572,6 @@ For technical support or questions about this API, please contact our developmen
             advancedLoadUpKwh: {
               summary: 'CTA-2045 Advanced Load Up (example: minimum +3 kWh above normal)',
               value: {
-                event_id: '8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f',
                 event_type: 'ADVANCED_LOAD_UP',
                 event_data: {
                   device_id: '000012',
@@ -165,7 +580,6 @@ For technical support or questions about this API, please contact our developmen
                   value: 3,
                   units: 3,
                   suggested_load_up_efficiency: 0,
-                  event_id: '8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f',
                   start_randomization: 0,
                   end_randomization: 0,
                 },
@@ -174,7 +588,6 @@ For technical support or questions about this API, please contact our developmen
             advancedLoadUpNoEffect: {
               summary: 'CTA-2045 Advanced Load Up (no-effect / capability check)',
               value: {
-                event_id: '9d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f',
                 event_type: 'ADVANCED_LOAD_UP',
                 event_data: {
                   device_id: '000012',
@@ -183,7 +596,6 @@ For technical support or questions about this API, please contact our developmen
                   value: 0,
                   units: 255,
                   suggested_load_up_efficiency: 0,
-                  event_id: '9d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f',
                   start_randomization: 0,
                   end_randomization: 0,
                 },
@@ -217,7 +629,7 @@ For technical support or questions about this API, please contact our developmen
           sidebar: { backgroundColor: '#f8fafc', textColor: '#1e293b' },
         },
       },
-    })
+    } as never)
     const res = await handler(c, noopNext)
     if (!res) {
       throw new Error('Scalar API reference middleware did not return a response')

--- a/lambda/events/events.ts
+++ b/lambda/events/events.ts
@@ -383,9 +383,9 @@ app.post("/",
         description: `Creates a new event (command) or a batch of events for one or more devices. The \`event_data\` structure varies by \`event_type\`.
 
 Notes:
-- For CTA-2045 Advanced Load Up, use \`event_type: ADVANCED_LOAD_UP\` and provide CTA fields in \`event_data\` (including \`value\`, \`units\`, and \`event_data.event_id\`).
+- For CTA-2045 Advanced Load Up, use \`event_type: ADVANCED_LOAD_UP\` and provide CTA fields in \`event_data\` (including \`value\` and \`units\`).
 - \`LOAD_UP.duration\` is interpreted as seconds, but \`ADVANCED_LOAD_UP.duration\` is interpreted as minutes.
-- Advanced Load Up has two IDs: the top-level \`event_id\` (API request ID) and \`event_data.event_id\` (CTA Event ID sent to the device). Recommended: reuse the same UUID for both.`,
+- Event IDs and delivery status are server-owned response fields. Do not send \`event_id\` or \`event_sent\` in event requests.`,
         requestBody: {
             required: true,
             content: {
@@ -395,7 +395,6 @@ Notes:
                         loadUpSingleDevice: {
                             summary: 'Load Up Event for a Single Device',
                             value: {
-                                event_id: "a1b2c3d4-e5f6-7890-1234-567890abcdef",
                                 event_type: "LOAD_UP",
                                 event_data: {
                                     device_id: "000012",
@@ -407,7 +406,6 @@ Notes:
                         loadUpMultipleDevices: {
                             summary: 'Load Up Event for Multiple Devices',
                             value: {
-                                event_id: "b2c3d4e5-f6a7-8901-2345-67890abcdef0",
                                 event_type: "LOAD_UP",
                                 event_data: {
                                     device_id: ["000012", "000013"],
@@ -419,7 +417,6 @@ Notes:
                         infoRequest: {
                             summary: 'Info Request Event',
                             value: {
-                                event_id: "c3d4e5f6-a7b8-9012-3456-7890abcdef01",
                                 event_type: "INFO_REQUEST",
                                 event_data: {
                                     device_id: "000012",
@@ -430,7 +427,6 @@ Notes:
                         advancedLoadUpKwh: {
                             summary: 'CTA-2045 Advanced Load Up (example: minimum +3 kWh above normal)',
                             value: {
-                                event_id: "8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
                                 event_type: "ADVANCED_LOAD_UP",
                                 event_data: {
                                     device_id: "000012",
@@ -439,7 +435,6 @@ Notes:
                                     value: 3,
                                     units: 3,
                                     suggested_load_up_efficiency: 0,
-                                    event_id: "8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
                                     start_randomization: 0,
                                     end_randomization: 0
                                 }
@@ -448,7 +443,6 @@ Notes:
                         advancedLoadUpNoEffect: {
                             summary: 'CTA-2045 Advanced Load Up (no-effect / capability check)',
                             value: {
-                                event_id: "9d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
                                 event_type: "ADVANCED_LOAD_UP",
                                 event_data: {
                                     device_id: "000012",
@@ -457,7 +451,6 @@ Notes:
                                     value: 0,
                                     units: 255,
                                     suggested_load_up_efficiency: 0,
-                                    event_id: "9d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f",
                                     start_randomization: 0,
                                     end_randomization: 0
                                 }
@@ -474,23 +467,20 @@ Notes:
                     'application/json': {
                         schema: resolver(bulkResponseSchema),
                         example: {
-                            statusCode: 200,
-                            body: {
-                                successful_events: [
-                                    {
-                                        event_id: "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+                            successful_events: [
+                                {
+                                    event_id: "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+                                    event_type: "LOAD_UP",
+                                    event_data: {
                                         device_id: "000012",
-                                        event_type: "LOAD_UP",
-                                        timestamp: "2023-10-27T10:00:00Z",
-                                        event_data: {
-                                            start_time: "2023-10-27T10:00:00Z",
-                                            duration: 3600
-                                        },
-                                        event_ack: false
-                                    }
-                                ],
-                                failed_events: []
-                            }
+                                        start_time: 752148000,
+                                        duration: 3600,
+                                        event_sent: true
+                                    },
+                                    event_ack: false
+                                }
+                            ],
+                            failed_events: []
                         }
                     },
                 },

--- a/lambda/events/eventsSchema.ts
+++ b/lambda/events/eventsSchema.ts
@@ -26,43 +26,47 @@ const deviceIdSchema = z.union([
     z.array(z.union([z.string().uuid(), sixDigitDeviceId]))
 ]);
 
+const responseTimestampSchema = z.union([z.string().datetime(), z.number().int()]);
+
+const eventSentResponseSchema = z
+    .boolean()
+    .optional()
+    .openapi({
+        description: 'Server-owned delivery status. Returned by the API; do not send in event requests.',
+        readOnly: true,
+    });
+
 const startShedSchema = z.object({
     device_id: deviceIdSchema,
     start_time: z.string().datetime(),
     duration: z.number().optional(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const endShedSchema = z.object({
     device_id: deviceIdSchema,
     start_time: z.string().datetime().optional(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const loadUpSchema = z.object({
     device_id: deviceIdSchema,
     start_time: z.string().datetime(),
     duration: z.number().optional(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const gridEmergencySchema = z.object({
     device_id: deviceIdSchema,
     start_time: z.string().datetime(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const criticalPeakSchema = z.object({
     device_id: deviceIdSchema,
     start_time: z.string().datetime(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const infoRequestSchema = z.object({
     device_id: deviceIdSchema,
     timestamp: z.string().datetime().optional(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const advancedLoadUpSchema = z.object({
     device_id: deviceIdSchema,
@@ -108,14 +112,6 @@ const advancedLoadUpSchema = z.object({
             description: 'Suggested load up efficiency (UInt8). Set to 0 if unused.',
             example: 0,
         }),
-    event_id: z
-        .string()
-        .uuid()
-        .openapi({
-            description:
-                'CTA-2045 Event ID. This is sent to the device (GridCube encodes the first 4 bytes of the UUID). Recommended: reuse the top-level event_id.',
-            example: '8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f',
-        }),
     start_randomization: z
         .number()
         .int()
@@ -128,69 +124,163 @@ const advancedLoadUpSchema = z.object({
         .min(0)
         .max(255)
         .openapi({ description: 'End randomization in minutes (UInt8).', example: 0 }),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const customerOverrideSchema = z.object({
     device_id: deviceIdSchema,
     override: z.boolean(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const setUtcTimeSchema = z.object({
     device_id: deviceIdSchema,
     utc_seconds: z.number(),
     utc_offset: z.number(),
     dst_offset: z.number(),
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const getUtcTimeSchema = z.object({
     device_id: deviceIdSchema,
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
 
 const setBitmapSchema = z.object({
     device_id: deviceIdSchema,
     bit_number: z.number().min(0).max(255),
     set_value: z.boolean(),
-    event_sent: z.boolean().optional()
-});
+}).passthrough();
 
 const requestConnectionInfoSchema = z.object({
     device_id: deviceIdSchema,
-    event_sent: z.boolean().optional(),
-    last_rx_rssi: z.number().optional(),  // Last received signal strength indicator
-    last_rx_snr: z.number().optional(),   // Last received signal-to-noise ratio
-    last_rx_link_type: z.number().optional()  // Last received link type
-});
+}).passthrough();
 
 const startDataPublishSchema = z.object({
     device_id: deviceIdSchema,
     interval_minutes: z.number().min(1).max(65535), // UInt16 range
-    event_sent: z.boolean().optional(),
-});
+}).passthrough();
+
+const loadUpResponseSchema = loadUpSchema.extend({
+    start_time: responseTimestampSchema,
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const gridEmergencyResponseSchema = gridEmergencySchema.extend({
+    start_time: responseTimestampSchema,
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const criticalPeakResponseSchema = criticalPeakSchema.extend({
+    start_time: responseTimestampSchema,
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const startShedResponseSchema = startShedSchema.extend({
+    start_time: responseTimestampSchema,
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const endShedResponseSchema = endShedSchema.extend({
+    start_time: responseTimestampSchema.optional(),
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const infoRequestResponseSchema = infoRequestSchema.extend({
+    timestamp: responseTimestampSchema.optional(),
+    start_time: responseTimestampSchema.optional(),
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const advancedLoadUpResponseSchema = advancedLoadUpSchema.extend({
+    start_time: responseTimestampSchema,
+    event_id: z
+        .string()
+        .uuid()
+        .optional()
+        .openapi({
+            description: 'Server-owned CTA-2045 Event ID sent to the device. Returned by the API; do not send in event requests.',
+            example: '8d0b2c2e-2b8d-4d11-9f54-6d8c5d7b2a1f',
+            readOnly: true,
+        }),
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const customerOverrideResponseSchema = customerOverrideSchema.extend({
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const setUtcTimeResponseSchema = setUtcTimeSchema.extend({
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const getUtcTimeResponseSchema = getUtcTimeSchema.extend({
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const setBitmapResponseSchema = setBitmapSchema.extend({
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+const requestConnectionInfoResponseSchema = requestConnectionInfoSchema.extend({
+    event_sent: eventSentResponseSchema,
+    last_rx_rssi: z.number().optional().openapi({ description: 'Server-owned last received signal strength indicator.', readOnly: true }),
+    last_rx_snr: z.number().optional().openapi({ description: 'Server-owned last received signal-to-noise ratio.', readOnly: true }),
+    last_rx_link_type: z.number().optional().openapi({ description: 'Server-owned last received link type.', readOnly: true }),
+}).passthrough();
+
+const startDataPublishResponseSchema = startDataPublishSchema.extend({
+    event_sent: eventSentResponseSchema,
+}).passthrough();
+
+function eventRequestVariant<T extends z.ZodTypeAny>(eventType: EventType, eventData: T, title: string) {
+    return z
+        .object({
+            event_type: z.literal(eventType),
+            event_data: eventData,
+        })
+        .passthrough()
+        .openapi({ title });
+}
 
 const eventRequestSchema = z.discriminatedUnion('event_type', [
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.LOAD_UP), event_data: loadUpSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.GRID_EMERGENCY), event_data: gridEmergencySchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.CRITICAL_PEAK), event_data: criticalPeakSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.START_SHED), event_data: startShedSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.END_SHED), event_data: endShedSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.INFO_REQUEST), event_data: infoRequestSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.ADVANCED_LOAD_UP), event_data: advancedLoadUpSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.CUSTOMER_OVERRIDE), event_data: customerOverrideSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.SET_UTC_TIME), event_data: setUtcTimeSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.GET_UTC_TIME), event_data: getUtcTimeSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.SET_BITMAP), event_data: setBitmapSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.REQUEST_CONNECTION_INFO), event_data: requestConnectionInfoSchema }),
-    z.object({ event_id: z.string(), event_type: z.literal(EventType.START_DATA_PUBLISH), event_data: startDataPublishSchema }),
+    eventRequestVariant(EventType.LOAD_UP, loadUpSchema, 'LoadUpEventRequest'),
+    eventRequestVariant(EventType.GRID_EMERGENCY, gridEmergencySchema, 'GridEmergencyEventRequest'),
+    eventRequestVariant(EventType.CRITICAL_PEAK, criticalPeakSchema, 'CriticalPeakEventRequest'),
+    eventRequestVariant(EventType.START_SHED, startShedSchema, 'StartShedEventRequest'),
+    eventRequestVariant(EventType.END_SHED, endShedSchema, 'EndShedEventRequest'),
+    eventRequestVariant(EventType.INFO_REQUEST, infoRequestSchema, 'InfoRequestEventRequest'),
+    eventRequestVariant(EventType.ADVANCED_LOAD_UP, advancedLoadUpSchema, 'AdvancedLoadUpEventRequest'),
+    eventRequestVariant(EventType.CUSTOMER_OVERRIDE, customerOverrideSchema, 'CustomerOverrideEventRequest'),
+    eventRequestVariant(EventType.SET_UTC_TIME, setUtcTimeSchema, 'SetUtcTimeEventRequest'),
+    eventRequestVariant(EventType.GET_UTC_TIME, getUtcTimeSchema, 'GetUtcTimeEventRequest'),
+    eventRequestVariant(EventType.SET_BITMAP, setBitmapSchema, 'SetBitmapEventRequest'),
+    eventRequestVariant(EventType.REQUEST_CONNECTION_INFO, requestConnectionInfoSchema, 'RequestConnectionInfoEventRequest'),
+    eventRequestVariant(EventType.START_DATA_PUBLISH, startDataPublishSchema, 'StartDataPublishEventRequest'),
 ]);
 
+const eventDataResponseSchema = z.union([
+    loadUpResponseSchema.openapi({ title: 'LoadUpEventData' }),
+    gridEmergencyResponseSchema.openapi({ title: 'GridEmergencyEventData' }),
+    criticalPeakResponseSchema.openapi({ title: 'CriticalPeakEventData' }),
+    startShedResponseSchema.openapi({ title: 'StartShedEventData' }),
+    endShedResponseSchema.openapi({ title: 'EndShedEventData' }),
+    infoRequestResponseSchema.openapi({ title: 'InfoRequestEventData' }),
+    advancedLoadUpResponseSchema.openapi({ title: 'AdvancedLoadUpEventData' }),
+    customerOverrideResponseSchema.openapi({ title: 'CustomerOverrideEventData' }),
+    setUtcTimeResponseSchema.openapi({ title: 'SetUtcTimeEventData' }),
+    getUtcTimeResponseSchema.openapi({ title: 'GetUtcTimeEventData' }),
+    setBitmapResponseSchema.openapi({ title: 'SetBitmapEventData' }),
+    requestConnectionInfoResponseSchema.openapi({ title: 'RequestConnectionInfoEventData' }),
+    startDataPublishResponseSchema.openapi({ title: 'StartDataPublishEventData' }),
+]).openapi({ title: 'EventData', unionOneOf: true } as never);
+
 const eventSchema = z.object({
-    event_id: z.string(),
+    event_id: z
+        .string()
+        .openapi({
+            description: 'Canonical server-generated event identifier. Returned by the API; do not send in event requests.',
+            example: 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
+            readOnly: true,
+        }),
     event_type: z.nativeEnum(EventType),
-    event_data: z.object({}).passthrough(),
+    event_data: eventDataResponseSchema,
     event_ack: z.boolean().optional().nullable(),
 });
 

--- a/test/openapi-vaw-6.test.ts
+++ b/test/openapi-vaw-6.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from '@jest/globals'
+import { createApp } from '../lambda/app.ts'
+import { eventRequestSchema } from '../lambda/events/eventsSchema.ts'
+
+type OpenApiObject = Record<string, any>
+
+async function loadSpec(): Promise<OpenApiObject> {
+  const response = await createApp().request('/public/openapi')
+
+  expect(response.status).toBe(200)
+  return response.json()
+}
+
+function eventPost(spec: OpenApiObject): OpenApiObject {
+  return spec.paths['/events'].post
+}
+
+function requestSchema(spec: OpenApiObject): OpenApiObject {
+  return eventPost(spec).requestBody.content['application/json'].schema
+}
+
+function requestExamples(spec: OpenApiObject): OpenApiObject[] {
+  return Object.values(eventPost(spec).requestBody.content['application/json'].examples).map((example: any) => example.value)
+}
+
+function hasKeyDeep(value: unknown, key: string): boolean {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  if (Object.prototype.hasOwnProperty.call(value, key)) {
+    return true
+  }
+
+  return Object.values(value).some((child) => hasKeyDeep(child, key))
+}
+
+describe('VAW-6 OpenAPI docs', () => {
+  it('documents event request payloads without server-owned fields', async () => {
+    const spec = await loadSpec()
+    const variants = requestSchema(spec).oneOf
+
+    expect(variants).toHaveLength(13)
+    for (const variant of variants) {
+      expect(variant.properties.event_id).toBeUndefined()
+      expect(variant.properties.event_data.properties.event_id).toBeUndefined()
+      expect(variant.properties.event_data.properties.event_sent).toBeUndefined()
+      expect(variant.required).toEqual(['event_type', 'event_data'])
+    }
+
+    for (const example of requestExamples(spec)) {
+      expect(hasKeyDeep(example, 'event_id')).toBe(false)
+      expect(hasKeyDeep(example, 'event_sent')).toBe(false)
+      expect(eventRequestSchema.safeParse(example).success).toBe(true)
+    }
+  })
+
+  it('labels event request variants with concrete schema names', async () => {
+    const spec = await loadSpec()
+    const labels = requestSchema(spec).oneOf.map((variant: OpenApiObject) => {
+      if (typeof variant.$ref === 'string') {
+        return variant.$ref.split('/').pop()
+      }
+      return variant.title
+    })
+
+    expect(labels).toEqual([
+      'LoadUpEventRequest',
+      'GridEmergencyEventRequest',
+      'CriticalPeakEventRequest',
+      'StartShedEventRequest',
+      'EndShedEventRequest',
+      'InfoRequestEventRequest',
+      'AdvancedLoadUpEventRequest',
+      'CustomerOverrideEventRequest',
+      'SetUtcTimeEventRequest',
+      'GetUtcTimeEventRequest',
+      'SetBitmapEventRequest',
+      'RequestConnectionInfoEventRequest',
+      'StartDataPublishEventRequest',
+    ])
+  })
+
+  it('documents server-owned event response fields as response-only', async () => {
+    const spec = await loadSpec()
+    const responseSchema = eventPost(spec).responses[200].content['application/json'].schema
+    const eventSchema = responseSchema.properties.successful_events.items
+
+    expect(eventSchema.properties.event_id.readOnly).toBe(true)
+    expect(eventSchema.properties.event_id.description).toContain('server-generated')
+    expect(eventSchema.properties.event_data.oneOf).toBeDefined()
+    expect(JSON.stringify(eventSchema.properties.event_data)).toContain('event_sent')
+  })
+
+  it('includes auth request, success, and error examples', async () => {
+    const spec = await loadSpec()
+    const authPaths = [
+      '/public/auth/register',
+      '/public/auth/confirm-registration',
+      '/public/auth/login',
+      '/public/auth/forgot-password',
+      '/public/auth/reset-password',
+      '/public/auth/refresh-token',
+    ]
+
+    for (const path of authPaths) {
+      const operation = spec.paths[path].post
+      const requestJson = operation.requestBody.content['application/json']
+      const successStatus = operation.responses[201] ? 201 : 200
+      const successJson = operation.responses[successStatus].content['application/json']
+      const errorStatus = operation.responses[401] ? 401 : 400
+      const errorJson = operation.responses[errorStatus].content['application/json']
+
+      expect(requestJson.example || requestJson.examples).toBeDefined()
+      expect(successJson.example || successJson.examples).toBeDefined()
+      expect(errorJson.example || errorJson.examples).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- remove server-owned event fields from event request schemas and examples
- add concrete event request/response schema labels and response-only annotations for event IDs and delivery status
- add auth request/success/error examples and update stale markdown snippets

## Validation
- bunx jest test/openapi-vaw-6.test.ts --runInBand
- bun run test:unit
- bun run lint
- bun run build (fails on existing Jest global typing errors in unrelated test files: test/device-filtering.test.ts, test/device-id-mapping.test.ts, test/testUtils.ts)