### PR TITLE
[codex] Deploy production from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Deploy
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       environment:
@@ -24,7 +26,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ github.event_name == 'push' && 'production' || inputs.environment }}
 
     steps:
       - name: Checkout code
@@ -33,29 +35,29 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.2.2"
+          bun-version: '1.2.2'
 
       - name: Install dependencies
         run: bun install
 
       - name: Configure AWS credentials (develop)
-        if: ${{ inputs.environment == 'develop' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.environment == 'develop' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_DEVELOP }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Configure AWS credentials (production)
-        if: ${{ inputs.environment == 'production' }}
+        if: ${{ github.event_name == 'push' || inputs.environment == 'production' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_PRODUCTION }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Deploy
-        if: ${{ !inputs.diff_only }}
-        run: bun run cdk deploy --all --context environment=${{ inputs.environment }} --require-approval never
+        if: ${{ github.event_name == 'push' || !inputs.diff_only }}
+        run: bun run deploy --env ${{ github.event_name == 'push' && 'production' || inputs.environment }} --ci
 
       - name: Diff only
-        if: ${{ inputs.diff_only }}
-        run: bun run cdk diff --all --context environment=${{ inputs.environment }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.diff_only }}
+        run: bun run deploy --env ${{ inputs.environment }} --ci --diff-only

--- a/docs/operations/ci-cd.md
+++ b/docs/operations/ci-cd.md
@@ -11,7 +11,12 @@ Both run Bun-based test checks.
 
 - `.github/workflows/deploy.yml`
 
-Manual trigger (`workflow_dispatch`) with:
+Automatic trigger:
+
+- Pushes to `main` deploy `production`.
+
+Manual trigger (`workflow_dispatch`) still supports:
+
 - `environment`: `develop` or `production`
 - `diff_only`: `true` or `false`
 
@@ -33,4 +38,5 @@ bun run deploy --env <develop|production> --ci --diff-only
 - `AWS_ROLE_TO_ASSUME_PRODUCTION`
 
 Optional repo variable:
+
 - `AWS_REGION` (defaults to `us-east-1`)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "cdk": "cdk",
+    "deploy": "bun scripts/deploy.ts",
     "deploy:develop": "bun scripts/require-node20.ts && bun run --cwd frontend-react build:develop && cdk deploy --all --context environment=develop --profile dobby_develop",
     "deploy:production": "bun scripts/require-node20.ts && bun run --cwd frontend-react build:production && cdk deploy --all --context environment=production --profile dobby_production",
     "destroy": "cdk destroy --all",

--- a/test/frontend-deploy-safety.test.ts
+++ b/test/frontend-deploy-safety.test.ts
@@ -11,26 +11,47 @@ function makeTempBuild(): string {
 }
 
 describe('frontend deploy safety', () => {
+  test('deploy workflow deploys production from main with the unified deploy command', () => {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    const deployWorkflow = fs.readFileSync(
+      path.join(repoRoot, '.github', 'workflows', 'deploy.yml'),
+      'utf8',
+    );
+
+    expect(packageJson.scripts.deploy).toBe('bun scripts/deploy.ts');
+    expect(deployWorkflow).toContain('push:');
+    expect(deployWorkflow).toContain('branches: [main]');
+    expect(deployWorkflow).toContain(
+      "environment: ${{ github.event_name == 'push' && 'production' || inputs.environment }}",
+    );
+    expect(deployWorkflow).toContain(
+      "if: ${{ github.event_name == 'push' || inputs.environment == 'production' }}",
+    );
+    expect(deployWorkflow).toContain(
+      "bun run deploy --env ${{ github.event_name == 'push' && 'production' || inputs.environment }} --ci",
+    );
+  });
+
   test('deploy scripts build the matching frontend artifact before CDK deploy', () => {
     const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
 
     expect(packageJson.scripts['deploy:develop']).toContain('scripts/require-node20.ts');
     expect(packageJson.scripts['deploy:production']).toContain('scripts/require-node20.ts');
     expect(packageJson.scripts['deploy:develop']).toContain(
-      'bun run --cwd frontend-react build:develop'
+      'bun run --cwd frontend-react build:develop',
     );
     expect(packageJson.scripts['deploy:production']).toContain(
-      'bun run --cwd frontend-react build:production'
+      'bun run --cwd frontend-react build:production',
     );
     expect(packageJson.scripts['deploy:develop'].indexOf('scripts/require-node20.ts')).toBeLessThan(
-      packageJson.scripts['deploy:develop'].indexOf('bun run --cwd frontend-react build:develop')
+      packageJson.scripts['deploy:develop'].indexOf('bun run --cwd frontend-react build:develop'),
     );
     expect(
-      packageJson.scripts['deploy:production'].indexOf('scripts/require-node20.ts')
+      packageJson.scripts['deploy:production'].indexOf('scripts/require-node20.ts'),
     ).toBeLessThan(
       packageJson.scripts['deploy:production'].indexOf(
-        'bun run --cwd frontend-react build:production'
-      )
+        'bun run --cwd frontend-react build:production',
+      ),
     );
   });
 


### PR DESCRIPTION
## Summary
- Trigger the deploy workflow on pushes to `main` so merged code deploys to production.
- Route deploy and diff jobs through `bun run deploy --env ... --ci` so CI uses the same frontend build/CDK wrapper as documented.
- Add a regression test covering the automatic production deploy workflow wiring.

## Validation
- `bunx prettier --check package.json .github/workflows/deploy.yml docs/operations/ci-cd.md test/frontend-deploy-safety.test.ts`
- `bunx jest test/frontend-deploy-safety.test.ts --runInBand`
- `bun run build`
- `bun run test:unit`
- `bun run lint`