### PR TITLE
[VAW-24] Store Sidewalk RSSI metadata

### DIFF
--- a/data-handler-ts/src/index.ts
+++ b/data-handler-ts/src/index.ts
@@ -9,8 +9,9 @@ import { handleOperationalState } from './packet-handlers/operational-state';
 import { handleConnectionInfo } from './packet-handlers/connection-info';
 import { handleGridcubeFwVersion } from './packet-handlers/gridcube-fw-version';
 import { handleEventAcknowledgment } from './packet-handlers/event-acknowledgment';
+import { writeSidewalkMetadataToDynamo, SidewalkMetadataEvent } from './utils/sidewalk-metadata';
 
-interface DobbyDataHandlerEvent {
+interface DobbyDataHandlerEvent extends SidewalkMetadataEvent {
   WirelessDeviceId: string;
   PayloadData: string;
 }
@@ -21,6 +22,8 @@ export const handler = async (event: DobbyDataHandlerEvent): Promise<APIGatewayP
 
     const deviceId = event.WirelessDeviceId;
     const payload = event.PayloadData;
+
+    await writeSidewalkMetadataToDynamo(deviceId, event);
 
     // First decode base64 to get hex string
     const base64Decoded = Buffer.from(payload, 'base64').toString();

--- a/data-handler-ts/src/utils/sidewalk-metadata.test.ts
+++ b/data-handler-ts/src/utils/sidewalk-metadata.test.ts
@@ -1,0 +1,40 @@
+import { writeSidewalkMetadataToDynamo } from './sidewalk-metadata';
+import { writeDeviceInfoToDynamo } from './dynamo';
+
+jest.mock('./dynamo', () => ({
+  writeDeviceInfoToDynamo: jest.fn(),
+}));
+
+const mockedWriteDeviceInfoToDynamo = jest.mocked(writeDeviceInfoToDynamo);
+
+describe('writeSidewalkMetadataToDynamo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores Sidewalk RSSI metadata separately from device RSSI', async () => {
+    await writeSidewalkMetadataToDynamo('wireless-device-1', {
+      WirelessMetadata: {
+        Sidewalk: {
+          Rssi: -22,
+        },
+      },
+    });
+
+    expect(mockedWriteDeviceInfoToDynamo).toHaveBeenCalledWith(
+      'wireless-device-1',
+      'sidewalk_rssi',
+      -22
+    );
+  });
+
+  it('does not write when Sidewalk RSSI metadata is absent', async () => {
+    await writeSidewalkMetadataToDynamo('wireless-device-1', {
+      WirelessMetadata: {
+        Sidewalk: {},
+      },
+    });
+
+    expect(mockedWriteDeviceInfoToDynamo).not.toHaveBeenCalled();
+  });
+});

--- a/data-handler-ts/src/utils/sidewalk-metadata.ts
+++ b/data-handler-ts/src/utils/sidewalk-metadata.ts
@@ -1,0 +1,26 @@
+import { writeDeviceInfoToDynamo } from './dynamo';
+
+export interface SidewalkMetadataEvent {
+  WirelessMetadata?: {
+    Sidewalk?: {
+      Rssi?: number;
+    };
+  };
+}
+
+export const getSidewalkRssi = (event: SidewalkMetadataEvent): number | undefined => {
+  const rssi = event.WirelessMetadata?.Sidewalk?.Rssi;
+  return typeof rssi === 'number' && Number.isFinite(rssi) ? rssi : undefined;
+};
+
+export const writeSidewalkMetadataToDynamo = async (
+  deviceId: string,
+  event: SidewalkMetadataEvent
+): Promise<void> => {
+  const sidewalkRssi = getSidewalkRssi(event);
+  if (sidewalkRssi === undefined) {
+    return;
+  }
+
+  await writeDeviceInfoToDynamo(deviceId, 'sidewalk_rssi', sidewalkRssi);
+};

--- a/docs/protocols/gridcube-cta-2045-sidewalk.md
+++ b/docs/protocols/gridcube-cta-2045-sidewalk.md
@@ -83,6 +83,12 @@ Uplink:
 5. Parsed values are stored in DynamoDB via `data-handler-ts/src/utils/dynamo.ts`
    and some telemetry packets are ACKed back to the device.
 
+AWS IoT Wireless Sidewalk uplinks can also include
+`WirelessMetadata.Sidewalk.Rssi`. That value is the Sidewalk network/gateway RSSI
+for the uplink path, not the GridCube device-reported RSSI from response type
+`7`. The data handler stores it in `DobbyInfo.sidewalk_rssi`; the API exposes it
+as `last_sidewalk_rssi`.
+
 ## Time Fields
 
 The protocol uses two time concepts. Keep them distinct.

--- a/frontend-react/src/types/index.ts
+++ b/frontend-react/src/types/index.ts
@@ -17,6 +17,7 @@ export interface Device {
     serial_number: string;
     vendor_id: string;
     last_rx_rssi?: number;
+    last_sidewalk_rssi?: number;
     last_link_type?: number;
 }
 
@@ -53,4 +54,4 @@ export interface Event {
     event_type: EventType;
     event_data: EventData;
     event_ack?: boolean;  // Acknowledgment status from device
-} 
+}

--- a/lambda/devices/devices.ts
+++ b/lambda/devices/devices.ts
@@ -43,6 +43,12 @@ const transformDeviceData = (device: any) => {
         device.last_rx_rssi = Number(device.rssi);
         delete device.rssi;
     }
+
+    // Map Sidewalk metadata RSSI separately from device-reported RSSI
+    if (device.sidewalk_rssi !== undefined) {
+        device.last_sidewalk_rssi = Number(device.sidewalk_rssi);
+        delete device.sidewalk_rssi;
+    }
     
     // Map link_type to last_link_type and convert to number
     if (device.link_type !== undefined) {
@@ -53,6 +59,10 @@ const transformDeviceData = (device: any) => {
     // Convert other string values to numbers for fields expected to be numbers
     if (device.last_rx_rssi !== undefined && typeof device.last_rx_rssi === 'string') {
         device.last_rx_rssi = Number(device.last_rx_rssi);
+    }
+
+    if (device.last_sidewalk_rssi !== undefined && typeof device.last_sidewalk_rssi === 'string') {
+        device.last_sidewalk_rssi = Number(device.last_sidewalk_rssi);
     }
     
     if (device.last_link_type !== undefined && typeof device.last_link_type === 'string') {

--- a/lambda/devices/devicesSchema.ts
+++ b/lambda/devices/devicesSchema.ts
@@ -21,6 +21,7 @@ const deviceSchema = z.object({
     serial_number: z.string().optional(),
     vendor_id: z.coerce.string().optional(), // Coerce numbers to strings for resilience
     last_rx_rssi: z.number().optional(), // Signal strength in dBm
+    last_sidewalk_rssi: z.number().optional(), // Sidewalk gateway signal strength in dBm
     last_link_type: z.number().optional(), // 1 for BLE, 4 for LoRA
 });
 

--- a/lambda/events/eventsSchema.ts
+++ b/lambda/events/eventsSchema.ts
@@ -221,6 +221,7 @@ const setBitmapResponseSchema = setBitmapSchema.extend({
 const requestConnectionInfoResponseSchema = requestConnectionInfoSchema.extend({
     event_sent: eventSentResponseSchema,
     last_rx_rssi: z.number().optional().openapi({ description: 'Server-owned last received signal strength indicator.', readOnly: true }),
+    last_sidewalk_rssi: z.number().optional().openapi({ description: 'Server-owned Sidewalk gateway RSSI from AWS uplink metadata.', readOnly: true }),
     last_rx_snr: z.number().optional().openapi({ description: 'Server-owned last received signal-to-noise ratio.', readOnly: true }),
     last_rx_link_type: z.number().optional().openapi({ description: 'Server-owned last received link type.', readOnly: true }),
 }).passthrough();

--- a/test/device-sidewalk-rssi-schema.test.ts
+++ b/test/device-sidewalk-rssi-schema.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from '@jest/globals';
+import { deviceSchema } from '../lambda/devices/devicesSchema.ts';
+
+describe('deviceSchema Sidewalk RSSI', () => {
+    it('keeps Sidewalk RSSI separate from device-reported RSSI', () => {
+        const result = deviceSchema.safeParse({
+            device_id: '000012',
+            last_rx_rssi: -70,
+            last_sidewalk_rssi: -22,
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect((result.data as { last_sidewalk_rssi?: number }).last_sidewalk_rssi).toBe(-22);
+            expect(result.data.last_rx_rssi).toBe(-70);
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Stores AWS IoT Wireless Sidewalk uplink `WirelessMetadata.Sidewalk.Rssi` in `DobbyInfo.sidewalk_rssi`.
- Exposes the value as `last_sidewalk_rssi` separately from GridCube device-reported `last_rx_rssi`.
- Documents the two RSSI sources and adds data-handler/API schema tests.

## Linear
- VAW-24

## Verification
- `npm test -- --runTestsByPath src/utils/sidewalk-metadata.test.ts` in `data-handler-ts/`
- `npm test` in `data-handler-ts/`
- `npm run build` in `data-handler-ts/`
- `bun test test/device-sidewalk-rssi-schema.test.ts`
- `bun run test -- test/device-sidewalk-rssi-schema.test.ts`
- `bun run build`
- `bun run test:unit`
- `bun run lint` in `frontend-react/`
- `bun run build` in `frontend-react/`

Notes: root Jest still emits its existing worker teardown warning after passing; frontend build still reports stale Browserslist data after compiling successfully.